### PR TITLE
Fix function prototypes

### DIFF
--- a/tests/excit_composition.c
+++ b/tests/excit_composition.c
@@ -100,7 +100,7 @@ void test_composition_iterator(excit_t source, excit_t indexer)
 	}
 }
 
-int main()
+int main(void)
 {
 	excit_t source, indexer, source2, indexer2;
 

--- a/tests/excit_cons.c
+++ b/tests/excit_cons.c
@@ -109,7 +109,7 @@ void test_cons_iterator(int window, excit_t sit)
 	}
 }
 
-int main()
+int main(void)
 {
 	excit_t it1, it2, it3;
 

--- a/tests/excit_hilbert2d.c
+++ b/tests/excit_hilbert2d.c
@@ -109,7 +109,7 @@ void test_hilbert2d_iterator(int order)
 
 }
 
-int main()
+int main(void)
 {
 	test_hilbert2d_iterator(3);
 	test_hilbert2d_iterator(4);

--- a/tests/excit_index.c
+++ b/tests/excit_index.c
@@ -77,7 +77,7 @@ void run_tests(const ssize_t len, const ssize_t *index)
 	}
 }
 
-int main()
+int main(void)
 {
 	ssize_t n = NTESTS;
 

--- a/tests/excit_loop.c
+++ b/tests/excit_loop.c
@@ -100,7 +100,7 @@ void test_loop_iterator(int loop, excit_t sit)
 	}
 }
 
-int main()
+int main(void)
 {
 	excit_t it1, it2, it3;
 

--- a/tests/excit_product.c
+++ b/tests/excit_product.c
@@ -229,7 +229,7 @@ void test_product_split_dim(void)
 	excit_free(it);
 }
 
-int main()
+int main(void)
 {
 	excit_t its[4];
 

--- a/tests/excit_range.c
+++ b/tests/excit_range.c
@@ -76,7 +76,7 @@ void test_range_iterator(ssize_t start, ssize_t stop, ssize_t step)
 	}
 }
 
-int main()
+int main(void)
 {
 	test_range_iterator(4, 12, 3);
 	test_range_iterator(0, 3, 1);

--- a/tests/excit_repeat.c
+++ b/tests/excit_repeat.c
@@ -134,7 +134,7 @@ void test_repeat_iterator(int repeat, excit_t sit)
 	}
 }
 
-int main()
+int main(void)
 {
 	excit_t it1, it2, it3;
 

--- a/tests/excit_tleaf.c
+++ b/tests/excit_tleaf.c
@@ -248,7 +248,7 @@ void run_tests(const ssize_t depth, const ssize_t *arities)
 	}
 }
 
-int main()
+int main(void)
 {
 	ssize_t depth = 4;
 	const ssize_t arities_0[4] = { 4, 8, 2, 4 };


### PR DESCRIPTION
Cray compiler on Crusher compute nodes really doesn't like non-prototype function declarations (at least when invoked with `-Werror`, as we do).